### PR TITLE
added TAG parameter to docker-image-remove-pattern

### DIFF
--- a/00-docker-baids
+++ b/00-docker-baids
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 function docker-container-grep() {
     PATTERN=$@
@@ -139,7 +139,7 @@ function docker-image-grep() {
 }
 
 function docker-image-most-recent() {
-    
+
     docker images | grep -v ^REPOSITORY | head -n1 | awk '{print $3}'
 
 }
@@ -159,7 +159,7 @@ function docker-image-remove-orphan() {
 
 function docker-image-remove-pattern() {
     PATTERN=$@
-    docker-image-grep $PATTERN | awk '{print $1}' | xargs -rI % bash -c 'docker rmi %'
+    docker-image-grep $PATTERN | awk '{print $1":"$2}' | xargs -rI % bash -c 'docker rmi %'
 }
 
 function docker-volumes-remove-orphan() {


### PR DESCRIPTION
Sometimes when cleaning images using the pattern search they are not removed at all.

After messing with the parameters I've managed to solve it adding the TAG parameter in the list of found images to be deleted.